### PR TITLE
fix(spark): disable background profiler

### DIFF
--- a/config/spark/config.json
+++ b/config/spark/config.json
@@ -1,4 +1,4 @@
 {
   "_header": "spark configuration file - https://spark.lucko.me/docs/Configuration",
-  "backgroundProfiler": true
+  "backgroundProfiler": false
 }


### PR DESCRIPTION
Fix #134

spark's background profiler can hang the world shutdown. Turning it off keeps that path clear. On-demand `/spark profiler` is unaffected.